### PR TITLE
Patch QR code generation

### DIFF
--- a/packages/modal/src/flow/HandshakeOpen.tsx
+++ b/packages/modal/src/flow/HandshakeOpen.tsx
@@ -18,7 +18,7 @@ export const HandshakeOpen: FC<{ onCopy: (uri: string) => void }> = ({
   const generateQRCode = useCallback((uri: string) => {
     // qrcode-generator ships a callable export as default, but its types are wrong
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const QR: any = (QRCode as any).default ?? QRCode;
+    const QR: any = (QRCode as any).default;
 
     const qr = QR(0, "M");
 


### PR DESCRIPTION
Default import was changed to a glob import in commit [69acf6e](https://github.com/v3xlabs/open-lavatory/commit/69acf6eb23e61d4ac9df29176566d1cb4e06f149) because it can only be used with a default import when using the 'allowSyntheticDefaultImports' flag.