### PR TITLE
Fix QR code rendering in webkit based browsers

### DIFF
--- a/packages/modal/src/flow/HandshakeOpen.tsx
+++ b/packages/modal/src/flow/HandshakeOpen.tsx
@@ -34,7 +34,7 @@ export const HandshakeOpen: FC<{ onCopy: (uri: string) => void }> = ({
         {uri && (
           <div className="relative mx-auto flex w-fit items-center justify-center rounded-lg border-2 border-gray-200 bg-gray-50 p-4">
             <button
-              className="flex h-[200px] w-[200px] cursor-pointer items-center justify-center"
+              className="h-[200px] w-[200px] cursor-pointer"
               onClick={handleCopy}
               title="Click to copy connection URL"
               dangerouslySetInnerHTML={{ __html: generateQRCode(uri) }}


### PR DESCRIPTION
Webkit struggles with rendering a svg inside a flexbox without a width added to it. #gottalovebrowserstandards
